### PR TITLE
feat: print methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mighty.standards
 Title: Standard derivations for ADaM generation
-Version: 0.0.0.9003
+Version: 0.0.0.9004
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@enovonordisk.com", role = c("aut", "cre")),
     person("Novo Nordisk A/S", role = "cph")

--- a/R/mighty_component.R
+++ b/R/mighty_component.R
@@ -177,11 +177,13 @@ tags_to_depends <- function(tags) {
   i <- regexpr(pattern = " +", text = tags)
 
   data.frame(
-    domain = substr(x = tags, start = 1, stop = i - 1),
-    column = substr(x = tags, start = i + 1, stop = nchar(tags))
-  ) |>
-    apply(MARGIN = 2, FUN = gsub, pattern = "^ +| +$", replacement = "") |>
-    as.data.frame()
+    domain = tags |> 
+      substr(start = 1, stop = i - 1) |> 
+      trimws(),
+    column = tags |> 
+      substr(start = i + 1, stop = nchar(tags) |> 
+      trimws())
+  )
 }
 
 #' @noRd

--- a/R/mighty_component.R
+++ b/R/mighty_component.R
@@ -79,6 +79,11 @@ mighty_component <- R6::R6Class(
       ms_initialize(template, self, private)
     },
     #' @description
+    #' Print method displaying the component information.
+    print = function() {
+      ms_print(self)
+    },
+    #' @description
     #' Render component with supplied values.
     #' Supports mustache templates and uses `whisker::whisker.render()`.
     #' @param ... Parameters used to render the template.
@@ -111,11 +116,14 @@ mighty_component <- R6::R6Class(
     #' @field depends List of the components dependencies.
     depends = \() private$.depends,
     #' @field outputs List of the new columns created by the component.
-    outputs = \() private$.outputs
+    outputs = \() private$.outputs,
+    #' @field params List of parameters that need to be supplied when rendering the component.
+    params = \() private$.params
   ),
   private = list(
     .type = character(1),
-    .depends = list(),
+    .params = character(),
+    .depends = character(),
     .outputs = character(),
     .code = character(),
     .template = character()
@@ -126,6 +134,8 @@ mighty_component <- R6::R6Class(
 ms_initialize <- function(template, self, private) {
   # TODO: Input validation of template
   private$.type <- get_tag(template, "type")
+  private$.params <- get_tags(template, "param") |>
+    tags_to_named()
   private$.depends <- get_tags(template, "depends")
   private$.outputs <- get_tags(template, "outputs")
   private$.code <- grep(
@@ -142,7 +152,8 @@ ms_initialize <- function(template, self, private) {
 get_tags <- function(template, tag) {
   pattern <- paste0("^#' @", tag)
   tags <- grep(pattern = pattern, x = template, value = TRUE)
-  gsub(pattern = pattern, replacement = "", x = tags)
+  tags <- gsub(pattern = pattern, replacement = "", x = tags)
+  gsub(pattern = "^ +| +$", replacement = "", x = tags)
 }
 
 #' @noRd
@@ -154,4 +165,54 @@ get_tag <- function(template, tag) {
   }
 
   cli::cli_abort("Multiple or no matches found for tag: {tag}")
+}
+
+#' @noRd
+tags_to_named <- function(tags) {
+  i <- gregexpr(pattern = " ", text = tags) |>
+    vapply(FUN = \(x) x[[1]], FUN.VALUE = numeric(1))
+
+  names(tags) <- substr(x = tags, start = 1, stop = i - 1)
+  tags <- substr(x = tags, start = i + 1, stop = nchar(tags))
+  gsub(pattern = "^ +| +$", replacement = "", x = tags)
+}
+
+ms_print <- function(self) {
+  cli::cli({
+    cli::cli_text("{.cls {class(self)}}")
+    cli::cli_text("Type: {self$type}")
+
+    create_bullets(
+      header = "Parameters:",
+      bullets = paste(names(self$params), self$params, sep = ": ")
+    )
+    create_bullets(
+      header = "Depends:",
+      bullets = self$depends
+    )
+    create_bullets(
+      header = "Outputs:",
+      bullets = self$outputs
+    )
+  })
+
+  invisible(self)
+}
+
+create_bullets <- function(header, bullets) {
+  if (!length(bullets)) {
+    return(invisible())
+  }
+
+  cli::cli(
+    cli::cli_bullets(
+      c(
+        header,
+        setNames(
+          object = bullets,
+          nm = rep("*", times = length(bullets))
+        )
+      )
+    )
+  )
 }

--- a/R/mighty_component.R
+++ b/R/mighty_component.R
@@ -204,15 +204,10 @@ create_bullets <- function(header, bullets) {
     return(invisible())
   }
 
-  cli::cli(
-    cli::cli_bullets(
-      c(
-        header,
-        setNames(
-          object = bullets,
-          nm = rep("*", times = length(bullets))
-        )
-      )
-    )
-  )
+  cli::cli({
+    cli::cli_text("{header}")
+    for (i in seq_along(bullets)) {
+      cli::cli_li("{bullets[[i]]}")
+    }
+  })
 }

--- a/R/mighty_component.R
+++ b/R/mighty_component.R
@@ -177,12 +177,12 @@ tags_to_depends <- function(tags) {
   i <- regexpr(pattern = " +", text = tags)
 
   data.frame(
-    domain = tags |> 
-      substr(start = 1, stop = i - 1) |> 
+    domain = tags |>
+      substr(start = 1, stop = i - 1) |>
       trimws(),
-    column = tags |> 
-      substr(start = i + 1, stop = nchar(tags) |> 
-      trimws())
+    column = tags |>
+      substr(start = i + 1, stop = nchar(tags)) |>
+      trimws()
   )
 }
 

--- a/R/mighty_component.R
+++ b/R/mighty_component.R
@@ -187,7 +187,7 @@ tags_to_depends <- function(tags) {
 ms_print <- function(self) {
   cli::cli({
     cli::cli_text("{.cls {class(self)}}")
-    cli::cli_text("Type: {self$type}")
+    cli::cli_text("{.emph Type:} {self$type}")
 
     create_bullets(
       header = "Parameters:",
@@ -213,7 +213,7 @@ create_bullets <- function(header, bullets) {
   }
 
   cli::cli({
-    cli::cli_text("{header}")
+    cli::cli_text("{.emph {header}}")
     for (i in seq_along(bullets)) {
       cli::cli_li("{bullets[[i]]}")
     }

--- a/R/mighty_component.R
+++ b/R/mighty_component.R
@@ -80,6 +80,7 @@ mighty_component <- R6::R6Class(
     },
     #' @description
     #' Print method displaying the component information.
+    #' @return (`invisible`) self
     print = function() {
       ms_print(self)
     },

--- a/R/mighty_component_rendered.R
+++ b/R/mighty_component_rendered.R
@@ -24,6 +24,7 @@ mighty_component_rendered <- R6::R6Class(
     },
     #' @description
     #' Print rendered component
+    #' @return (`invisible`) self
     print = function() {
       msr_print(self, super)
     },
@@ -67,6 +68,8 @@ msr_print <- function(self, super) {
     cli::cli_text("{.emph Code:}")
     cli::cli_code(self$code)
   })
+
+  invisible(self)
 }
 
 #' @noRd

--- a/R/mighty_component_rendered.R
+++ b/R/mighty_component_rendered.R
@@ -20,6 +20,12 @@ mighty_component_rendered <- R6::R6Class(
     #' @param template `character` Rendered template such as output from `mighty_component$render()`.
     initialize = function(template) {
       super$initialize(template)
+      private$.params <- character()
+    },
+    #' @description
+    #' Print rendered component
+    print = function() {
+      msr_print(self, super)
     },
     #' @description
     #' Stream rendered code into a script (appended)
@@ -53,6 +59,15 @@ mighty_component_rendered <- R6::R6Class(
     }
   )
 )
+
+#' @noRd
+msr_print <- function(self, super) {
+  cli::cli({
+    super$print()
+    cli::cli_text("Code:")
+    cli::cli_code(self$code)
+  })
+}
 
 #' @noRd
 msr_stream <- function(path, self) {

--- a/R/mighty_component_rendered.R
+++ b/R/mighty_component_rendered.R
@@ -64,7 +64,7 @@ mighty_component_rendered <- R6::R6Class(
 msr_print <- function(self, super) {
   cli::cli({
     super$print()
-    cli::cli_text("Code:")
+    cli::cli_text("{.emph Code:}")
     cli::cli_code(self$code)
   })
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -21,6 +21,7 @@ CMD
 CRAN
 dplyr
 dtc
+emph
 envir
 knitr
 lintr

--- a/man/mighty_component.Rd
+++ b/man/mighty_component.Rd
@@ -87,6 +87,8 @@ the rendered code used in mighty becomes:
 \item{\code{depends}}{List of the components dependencies.}
 
 \item{\code{outputs}}{List of the new columns created by the component.}
+
+\item{\code{params}}{List of parameters that need to be supplied when rendering the component.}
 }
 \if{html}{\out{</div>}}
 }
@@ -94,6 +96,7 @@ the rendered code used in mighty becomes:
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-mighty_component-new}{\code{mighty_component$new()}}
+\item \href{#method-mighty_component-print}{\code{mighty_component$print()}}
 \item \href{#method-mighty_component-render}{\code{mighty_component$render()}}
 \item \href{#method-mighty_component-document}{\code{mighty_component$document()}}
 \item \href{#method-mighty_component-clone}{\code{mighty_component$clone()}}
@@ -115,6 +118,16 @@ Create standard component from template.
 }
 \if{html}{\out{</div>}}
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-mighty_component-print"></a>}}
+\if{latex}{\out{\hypertarget{method-mighty_component-print}{}}}
+\subsection{Method \code{print()}}{
+Print method displaying the component information.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{mighty_component$print()}\if{html}{\out{</div>}}
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-mighty_component-render"></a>}}

--- a/man/mighty_component.Rd
+++ b/man/mighty_component.Rd
@@ -128,6 +128,9 @@ Print method displaying the component information.
 \if{html}{\out{<div class="r">}}\preformatted{mighty_component$print()}\if{html}{\out{</div>}}
 }
 
+\subsection{Returns}{
+(\code{invisible}) self
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-mighty_component-render"></a>}}

--- a/man/mighty_component.Rd
+++ b/man/mighty_component.Rd
@@ -84,7 +84,7 @@ the rendered code used in mighty becomes:
 
 \item{\code{type}}{The type of the component. Can be one of predecessor, derivation, row.}
 
-\item{\code{depends}}{List of the components dependencies.}
+\item{\code{depends}}{Data.frame listing all the components dependencies.}
 
 \item{\code{outputs}}{List of the new columns created by the component.}
 

--- a/man/mighty_component_rendered.Rd
+++ b/man/mighty_component_rendered.Rd
@@ -66,6 +66,9 @@ Print rendered component
 \if{html}{\out{<div class="r">}}\preformatted{mighty_component_rendered$print()}\if{html}{\out{</div>}}
 }
 
+\subsection{Returns}{
+(\code{invisible}) self
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-mighty_component_rendered-stream"></a>}}

--- a/man/mighty_component_rendered.Rd
+++ b/man/mighty_component_rendered.Rd
@@ -24,6 +24,7 @@ Once rendered a component can be used to:
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-mighty_component_rendered-new}{\code{mighty_component_rendered$new()}}
+\item \href{#method-mighty_component_rendered-print}{\code{mighty_component_rendered$print()}}
 \item \href{#method-mighty_component_rendered-stream}{\code{mighty_component_rendered$stream()}}
 \item \href{#method-mighty_component_rendered-eval}{\code{mighty_component_rendered$eval()}}
 \item \href{#method-mighty_component_rendered-test}{\code{mighty_component_rendered$test()}}
@@ -55,6 +56,16 @@ Create standard component from rendered template.
 }
 \if{html}{\out{</div>}}
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-mighty_component_rendered-print"></a>}}
+\if{latex}{\out{\hypertarget{method-mighty_component_rendered-print}{}}}
+\subsection{Method \code{print()}}{
+Print rendered component
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{mighty_component_rendered$print()}\if{html}{\out{</div>}}
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-mighty_component_rendered-stream"></a>}}

--- a/tests/testthat/_snaps/components.md
+++ b/tests/testthat/_snaps/components.md
@@ -6,9 +6,9 @@
       <mighty_component_rendered/mighty_component/R6>
       Type: predecessor
       Depends:
-      * .self USUBJID
-      * pharmaverseadam::adsl USUBJID
-      * pharmaverseadam::adsl ACTARM
+      * .self.USUBJID
+      * pharmaverseadam::adsl.USUBJID
+      * pharmaverseadam::adsl.ACTARM
       Outputs:
       * ACTARM
       Code:
@@ -41,7 +41,8 @@
       <mighty_component_rendered/mighty_component/R6>
       Type: derivation
       Depends:
-      * .self AESTDTC
+      * .self
+      * AESTDTC
       Outputs:
       * ASTDT
       * ASTDTF
@@ -67,7 +68,8 @@
       <mighty_component_rendered/mighty_component/R6>
       Type: derivation
       Depends:
-      * .self AEENDTC
+      * .self
+      * AEENDTC
       Outputs:
       * AENDT
       * AENDTF
@@ -93,8 +95,8 @@
       <mighty_component_rendered/mighty_component/R6>
       Type: derivation
       Depends:
-      * .self ASTDT
-      * .self TRTSDT
+      * .self.ASTDT
+      * .self.TRTSDT
       Outputs:
       * ASTDY
       Code:
@@ -117,10 +119,10 @@
       <mighty_component_rendered/mighty_component/R6>
       Type: derivation
       Depends:
-      * .self ASTDT
-      * .self AENDT
-      * .self TRTSDT
-      * .self TRTEDT
+      * .self.ASTDT
+      * .self.AENDT
+      * .self.TRTSDT
+      * .self.TRTEDT
       Outputs:
       * TRTEMFL
       Code:

--- a/tests/testthat/_snaps/components.md
+++ b/tests/testthat/_snaps/components.md
@@ -41,8 +41,7 @@
       <mighty_component_rendered/mighty_component/R6>
       Type: derivation
       Depends:
-      * .self
-      * AESTDTC
+      * .self.AESTDTC
       Outputs:
       * ASTDT
       * ASTDTF
@@ -68,8 +67,7 @@
       <mighty_component_rendered/mighty_component/R6>
       Type: derivation
       Depends:
-      * .self
-      * AEENDTC
+      * .self.AEENDTC
       Outputs:
       * AENDT
       * AENDTF

--- a/tests/testthat/_snaps/components.md
+++ b/tests/testthat/_snaps/components.md
@@ -1,21 +1,17 @@
 # predecessor
 
     Code
-      cat(predecessor$template, sep = "\n")
-    Output
-      #' Predecessor
-      #' @description
-      #' Creates new column(s) based on a predecessor column(s).
-      #'
-      #' @param source `character` Name of the data set the predecessor is from
-      #' @param variable `character` Name of variable(s) to use from `source`
-      #' @param by `character` name(s) of variable(s) to merge by
-      #' @type predecessor
-      #' @depends .self USUBJID
-      #' @depends pharmaverseadam::adsl USUBJID
-      #' @depends pharmaverseadam::adsl ACTARM
-      #' @outputs ACTARM
-      
+      predecessor
+    Message
+      <mighty_component_rendered/mighty_component/R6>
+      Type: predecessor
+      Depends:
+      * .self USUBJID
+      * pharmaverseadam::adsl USUBJID
+      * pharmaverseadam::adsl ACTARM
+      Outputs:
+      * ACTARM
+      Code:
       .self <- .self |>
         dplyr::left_join(
           y = dplyr::select(pharmaverseadam::adsl, USUBJID, ACTARM),
@@ -25,17 +21,13 @@
 # assign
 
     Code
-      cat(assign$template, sep = "\n")
-    Output
-      #' Assign
-      #' @description
-      #' Assigns a single value to an entire column.
-      #'
-      #' @param variable `character` Name of variable to create or modify
-      #' @param value Value to assign to the variable
-      #' @type assigned
-      #' @outputs y
-      
+      assign
+    Message
+      <mighty_component_rendered/mighty_component/R6>
+      Type: assigned
+      Outputs:
+      * y
+      Code:
       .self <- .self |>
         dplyr::mutate(
           y = 1
@@ -44,19 +36,16 @@
 # astdt
 
     Code
-      cat(astdt$template, sep = "\n")
-    Output
-      #' Analysis start date
-      #' @description
-      #' Derives analysis start date based on (incomplete) dates given as
-      #' character
-      #'
-      #' @param dtc `character` Name of date variable
-      #' @type derivation
-      #' @depends .self AESTDTC
-      #' @outputs ASTDT
-      #' @outputs ASTDTF
-      
+      astdt
+    Message
+      <mighty_component_rendered/mighty_component/R6>
+      Type: derivation
+      Depends:
+      * .self AESTDTC
+      Outputs:
+      * ASTDT
+      * ASTDTF
+      Code:
       .self <- .self |>
         dplyr::mutate(
           ASTDT = admiral::convert_dtc_to_dt(
@@ -73,19 +62,16 @@
 # aendt
 
     Code
-      cat(astdt$template, sep = "\n")
-    Output
-      #' Analysis end date
-      #' @description
-      #' Derives analysis end date based on (incomplete) dates given as
-      #' character
-      #'
-      #' @param dtc `character` Name of date variable
-      #' @type derivation
-      #' @depends .self AEENDTC
-      #' @outputs AENDT
-      #' @outputs AENDTF
-      
+      aendt
+    Message
+      <mighty_component_rendered/mighty_component/R6>
+      Type: derivation
+      Depends:
+      * .self AEENDTC
+      Outputs:
+      * AENDT
+      * AENDTF
+      Code:
       .self <- .self |>
         dplyr::mutate(
           AENDT = admiral::convert_dtc_to_dt(
@@ -102,19 +88,16 @@
 # ady
 
     Code
-      cat(ady$template, sep = "\n")
-    Output
-      #' Analysis relative day
-      #' @description
-      #' Derives the relative day compared to the treatment start date.
-      #'
-      #' @param variable `character` Name of new variable to create
-      #' @param date `character` Name of date variable to use
-      #' @type derivation
-      #' @depends .self ASTDT
-      #' @depends .self TRTSDT
-      #' @outputs ASTDY
-      
+      ady
+    Message
+      <mighty_component_rendered/mighty_component/R6>
+      Type: derivation
+      Depends:
+      * .self ASTDT
+      * .self TRTSDT
+      Outputs:
+      * ASTDY
+      Code:
       .self <- .self |>
         dplyr::mutate(
           ASTDY = admiral::compute_duration(
@@ -129,20 +112,18 @@
 # trtemfl
 
     Code
-      cat(trtemfl$template, sep = "\n")
-    Output
-      #' Treatment-emergent flag
-      #' @description
-      #' Derives treatment emergent analysis flag.
-      #'
-      #' @param end_window Passed along to `admiral::end_window()`
-      #' @type derivation
-      #' @depends .self ASTDT
-      #' @depends .self AENDT
-      #' @depends .self TRTSDT
-      #' @depends .self TRTEDT
-      #' @outputs TRTEMFL
-      
+      trtemfl
+    Message
+      <mighty_component_rendered/mighty_component/R6>
+      Type: derivation
+      Depends:
+      * .self ASTDT
+      * .self AENDT
+      * .self TRTSDT
+      * .self TRTEDT
+      Outputs:
+      * TRTEMFL
+      Code:
       .self <- .self |>
         admiral::derive_var_trtemfl(
           start_date = ASTDT,

--- a/tests/testthat/test-components.R
+++ b/tests/testthat/test-components.R
@@ -4,8 +4,7 @@ test_that("predecessor", {
     list(source = "pharmaverseadam::adsl", by = "USUBJID", variable = "ACTARM")
   )
 
-  cat(predecessor$template, sep = "\n") |>
-    expect_snapshot()
+  expect_snapshot(predecessor)
 
   advs <- pharmaverseadam::advs |>
     dplyr::select(USUBJID, PARAMCD, AVAL, ACTARM)
@@ -19,8 +18,7 @@ test_that("predecessor", {
 test_that("assign", {
   assign <- get_rendered_standard("assign", list(variable = "y", value = 1))
 
-  cat(assign$template, sep = "\n") |>
-    expect_snapshot()
+  expect_snapshot(assign)
 
   df <- data.frame(x = "a", y = 1)
 
@@ -33,8 +31,7 @@ test_that("assign", {
 test_that("astdt", {
   astdt <- get_rendered_standard("astdt", list(dtc = "AESTDTC"))
 
-  cat(astdt$template, sep = "\n") |>
-    expect_snapshot()
+  expect_snapshot(astdt)
 
   adae <- pharmaverseadam::adae |>
     dplyr::select(USUBJID, AESTDTC, ASTDT, ASTDTF)
@@ -48,8 +45,7 @@ test_that("astdt", {
 test_that("aendt", {
   aendt <- get_rendered_standard("aendt", list(dtc = "AEENDTC"))
 
-  cat(aendt$template, sep = "\n") |>
-    expect_snapshot()
+  expect_snapshot(aendt)
 
   adae <- pharmaverseadam::adae |>
     dplyr::select(USUBJID, AEENDTC, AENDT, AENDTF)
@@ -63,8 +59,7 @@ test_that("aendt", {
 test_that("ady", {
   ady <- get_rendered_standard("ady", list(variable = "ASTDY", date = "ASTDT"))
 
-  cat(ady$template, sep = "\n") |>
-    expect_snapshot()
+  expect_snapshot(ady)
 
   adae <- pharmaverseadam::adae |>
     dplyr::select(USUBJID, ASTDT, TRTSDT, ASTDY)
@@ -84,8 +79,7 @@ test_that("ady", {
 test_that("trtemfl", {
   trtemfl <- get_rendered_standard("trtemfl", list(end_window = 30))
 
-  cat(trtemfl$template, sep = "\n") |>
-    expect_snapshot()
+  expect_snapshot(trtemfl)
 
   adae <- pharmaverseadam::adae |>
     dplyr::select(ASTDT, AENDT, TRTSDT, TRTEDT, TRTEMFL)

--- a/tests/testthat/test-mighty_component.R
+++ b/tests/testthat/test-mighty_component.R
@@ -1,3 +1,0 @@
-test_that("multiplication works", {
-  expect_equal(2 * 2, 4)
-})

--- a/tests/testthat/test-mighty_component.R
+++ b/tests/testthat/test-mighty_component.R
@@ -1,0 +1,3 @@
+test_that("multiplication works", {
+  expect_equal(2 * 2, 4)
+})


### PR DESCRIPTION
## Summary
Added print methods for `mighty_component` and `mighty_component_rendered`.

## Changes Made
- Added `params` to `mighty_component`.
- Print method for `mighty_component` displaying: type, parameters, depends, outputs.
- Print method for `mighty_component_rendered` displaying: type, depends, outputs, code.
- Added input validation for `render()` method using `params`.
- `depends` field is now a `data.frame` for easier user in {mighty}, but when printing it is shown as a list in the format of "domain.column".

## Testing
- Unit tests for the individual components have been updated to use snapshot of the print methods instead of the rendered templates.
- Failing Devskim linter due to remaining TODOs in the code related to other issues.
- Unit tests for the methods will be handled in #26, but check the pkgdown webpage to see the print methods.

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge
