### PR TITLE
feat: improve `list_standards()`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,3 @@
----
-name: PR Template
-about: Template for PRs.
-title: "[PR] PR name"
-labels: ''
-assignees: ''
----
-
 ## Summary
 (Summary of made changes with explanation of what and why)
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mighty.standards
 Title: Standard derivations for ADaM generation
-Version: 0.0.0.9007
+Version: 0.0.0.9008
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@enovonordisk.com", role = c("aut", "cre")),
     person("Matthew", "Phelps", , "mewp@enovonordisk.com", role = c("aut")),
@@ -28,6 +28,7 @@ Suggests:
     pharmaversesdtm,
     rmarkdown,
     testthat (>= 3.0.0),
+    tibble,
     tidyr,
     withr
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
 Suggests: 
     admiral,
     dplyr,
+    jsonlite,
     knitr,
     pharmaverseadam,
     pharmaversesdtm,

--- a/R/component.R
+++ b/R/component.R
@@ -39,7 +39,10 @@ get_component <- function(component) {
   switch(
     file_type,
     "r" = get_custom_r_function(component),
-    "mustache" = mighty_component$new(template = readLines(component)),
+    "mustache" = mighty_component$new(
+      template = readLines(component),
+      id = component
+    ),
     get_standard(component)
   )
 }

--- a/R/custom_r_components.R
+++ b/R/custom_r_components.R
@@ -7,7 +7,8 @@ get_custom_r_function <- function(path) {
     template = c(
       extract_function_metadata(code_string),
       extract_function_body(code_string)
-    )
+    ),
+    id = path
   )
 }
 

--- a/R/mighty_component.R
+++ b/R/mighty_component.R
@@ -211,6 +211,7 @@ tags_to_depends <- function(tags) {
 ms_print <- function(self) {
   cli::cli({
     cli::cli_text("{.cls {class(self)}}")
+    cli::cli_text("{.field {self$id}}: {self$description}")
     cli::cli_text("{.emph Type:} {self$type}")
 
     create_bullets(

--- a/R/mighty_component_rendered.R
+++ b/R/mighty_component_rendered.R
@@ -21,7 +21,10 @@ mighty_component_rendered <- R6::R6Class(
     #' @param id `character` ID of the component. Either name of standard or path to local.
     initialize = function(template, id) {
       super$initialize(template, id)
-      private$.params <- character()
+      private$.params <- data.frame(
+        name = character(),
+        description = character()
+      )
     },
     #' @description
     #' Print rendered component

--- a/R/mighty_component_rendered.R
+++ b/R/mighty_component_rendered.R
@@ -18,8 +18,9 @@ mighty_component_rendered <- R6::R6Class(
     #' @description
     #' Create standard component from rendered template.
     #' @param template `character` Rendered template such as output from `mighty_component$render()`.
-    initialize = function(template) {
-      super$initialize(template)
+    #' @param id `character` ID of the component. Either name of standard or path to local.
+    initialize = function(template, id) {
+      super$initialize(template, id)
       private$.params <- character()
     },
     #' @description

--- a/R/standard.R
+++ b/R/standard.R
@@ -40,7 +40,6 @@ get_rendered_standard <- function(standard, params = list()) {
 #' @param as Format to list the standards in.
 #' Default `character` just lists the names,
 #' while `list` and `tibble` show more detailed information.
-#' `mcp` returns a JSON list suitable for ingesting into LLMs as tools.
 #' @returns `character` vector of standard names
 #' @examples
 #' # Simple character list of all standard ids:
@@ -50,11 +49,6 @@ get_rendered_standard <- function(standard, params = list()) {
 #' list_standards(as = "tibble")
 #'
 #' # List (only showing first 2):
-#' list_standards(as = "list") |>
-#'   head(2) |>
-#'   str()
-#'
-#' # MCP for tooling purposes (only showing first 2):
 #' list_standards(as = "list") |>
 #'   head(2) |>
 #'   str()
@@ -90,12 +84,6 @@ list_standards <- function(as = c("character", "list", "tibble", "mcp")) {
       list_standards("list") |>
         tibble::enframe(name = NULL) |>
         tidyr::unnest_wider(col = "value")
-    },
-    mcp = {
-      # TODO: Add correct mcp format and test
-      rlang::check_installed("jsonlite")
-      list_standards("list") |>
-        jsonlite::toJSON()
     }
   )
 }

--- a/R/standard.R
+++ b/R/standard.R
@@ -40,6 +40,7 @@ get_rendered_standard <- function(standard, params = list()) {
 #' @param as Format to list the standards in.
 #' Default `character` just lists the names,
 #' while `list` and `tibble` show more detailed information.
+#' `mcp` returns a JSON list suitable for ingesting into LLMs as tools.
 #' @returns `character` vector of standard names
 #' @examples
 #' # Simple character list of all standard ids:
@@ -48,12 +49,17 @@ get_rendered_standard <- function(standard, params = list()) {
 #' # Tibble for an easy overview
 #' list_standards(as = "tibble")
 #'
-#' # List for tooling purposes (only showing first 2):
+#' # List (only showing first 2):
+#' list_standards(as = "list") |>
+#'   head(2) |>
+#'   str()
+#'
+#' # MCP for tooling purposes (only showing first 2):
 #' list_standards(as = "list") |>
 #'   head(2) |>
 #'   str()
 #' @export
-list_standards <- function(as = c("character", "list", "tibble")) {
+list_standards <- function(as = c("character", "list", "tibble", "mcp")) {
   as <- rlang::arg_match(as)
 
   switch(
@@ -84,6 +90,12 @@ list_standards <- function(as = c("character", "list", "tibble")) {
       list_standards("list") |>
         tibble::enframe(name = NULL) |>
         tidyr::unnest_wider(col = "value")
+    },
+    mcp = {
+      # TODO: Add correct mcp format and test
+      rlang::check_installed("jsonlite")
+      list_standards("list") |>
+        jsonlite::toJSON()
     }
   )
 }

--- a/R/standard.R
+++ b/R/standard.R
@@ -37,23 +37,60 @@ get_rendered_standard <- function(standard, params = list()) {
 #' @description
 #' List all available mighty standard components.
 #'
+#' @param as Format to list the standards in.
+#' Default `character` just lists the names,
+#' while `list` and `tibble` show more detailed information.
 #' @returns `character` vector of standard names
 #' @examples
-#' available_standards <- list_standards()
-#' cat(available_standards, sep = "\n")
+#' list_standards()
 #'
+#' list_standards(as = "tibble")
 #' @export
-list_standards <- function() {
-  templates <- standard_path() |>
-    list.files()
+list_standards <- function(as = c("character", "list", "tibble")) {
+  as <- rlang::arg_match(as)
 
-  gsub(pattern = "\\.mustache$", replacement = "", x = templates)
+  switch(
+    EXPR = as,
+    character = gsub(
+      pattern = "\\.mustache$",
+      replacement = "",
+      x = list.files(standard_path())
+    ),
+    list = list_standards(as = "character") |>
+      lapply(FUN = get_standard) |>
+      lapply(
+        FUN = get_fields,
+        fields = c(
+          "id",
+          "title",
+          "description",
+          "params",
+          "depends",
+          "outputs",
+          "code"
+        )
+      ),
+    tibble = {
+      rlang::check_installed("tibble")
+      rlang::check_installed("tidyr")
+
+      list_standards("list") |>
+        tibble::enframe(name = NULL) |>
+        tidyr::unnest_wider(col = "value")
+    }
+  )
 }
 
 #' @noRd
 standard_path <- function() {
   # TODO: Point to new path when implemented
   system.file("components", package = "mighty.standards")
+}
+
+#' @noRd
+get_fields <- function(x, fields) {
+  lapply(X = fields, FUN = \(field) x[[field]]) |>
+    stats::setNames(fields)
 }
 
 #' @noRd

--- a/R/standard.R
+++ b/R/standard.R
@@ -20,7 +20,10 @@
 #' @export
 get_standard <- function(standard) {
   template <- find_standard(standard)
-  mighty_component$new(template = readLines(template))
+  mighty_component$new(
+    template = readLines(template),
+    id = standard
+  )
 }
 
 #' @rdname get_standard

--- a/R/standard.R
+++ b/R/standard.R
@@ -42,9 +42,16 @@ get_rendered_standard <- function(standard, params = list()) {
 #' while `list` and `tibble` show more detailed information.
 #' @returns `character` vector of standard names
 #' @examples
+#' # Simple character list of all standard ids:
 #' list_standards()
 #'
+#' # Tibble for an easy overview
 #' list_standards(as = "tibble")
+#'
+#' # List for tooling purposes (only showing first 2):
+#' list_standards(as = "list") |>
+#'   head(2) |>
+#'   str()
 #' @export
 list_standards <- function(as = c("character", "list", "tibble")) {
   as <- rlang::arg_match(as)

--- a/R/standard.R
+++ b/R/standard.R
@@ -53,7 +53,7 @@ get_rendered_standard <- function(standard, params = list()) {
 #'   head(2) |>
 #'   str()
 #' @export
-list_standards <- function(as = c("character", "list", "tibble", "mcp")) {
+list_standards <- function(as = c("character", "list", "tibble")) {
   as <- rlang::arg_match(as)
 
   switch(

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -27,6 +27,7 @@ dtc
 emph
 envir
 IDVARVAL
+jsonlite
 knitr
 lintr
 multiarch

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -55,6 +55,7 @@ suppae
 Sweave
 testthat
 Thomsen
+tibble
 tidyr
 TRTEDT
 TRTEMFL

--- a/inst/components/ady.mustache
+++ b/inst/components/ady.mustache
@@ -1,4 +1,4 @@
-#' Analysis relative day
+#' @title Analysis relative day
 #' @description
 #' Derives the relative day compared to the treatment start date.
 #'

--- a/inst/components/aendt.mustache
+++ b/inst/components/aendt.mustache
@@ -1,4 +1,4 @@
-#' Analysis end date
+#' @title Analysis end date
 #' @description
 #' Derives analysis end date based on (incomplete) dates given as
 #' character

--- a/inst/components/assign.mustache
+++ b/inst/components/assign.mustache
@@ -1,4 +1,4 @@
-#' Assign
+#' @title Assign
 #' @description
 #' Assigns a single value to an entire column.
 #'

--- a/inst/components/astdt.mustache
+++ b/inst/components/astdt.mustache
@@ -1,4 +1,4 @@
-#' Analysis start date
+#' @title Analysis start date
 #' @description
 #' Derives analysis start date based on (incomplete) dates given as
 #' character

--- a/inst/components/predecessor.mustache
+++ b/inst/components/predecessor.mustache
@@ -1,4 +1,4 @@
-#' Predecessor
+#' @title Predecessor
 #' @description
 #' Creates new column(s) based on a predecessor column(s).
 #'

--- a/inst/components/supp_sdtm.mustache
+++ b/inst/components/supp_sdtm.mustache
@@ -1,4 +1,4 @@
-#' Add Supplementary Variable from SDTM
+#' @title Add Supplementary Variable from SDTM
 #' @description
 #' Add a variable from a supplementary SDTM domain.
 #'

--- a/inst/components/trtemfl.mustache
+++ b/inst/components/trtemfl.mustache
@@ -1,4 +1,4 @@
-#' Treatment-emergent flag
+#' @title Treatment-emergent flag
 #' @description
 #' Derives treatment emergent analysis flag.
 #'

--- a/man/list_standards.Rd
+++ b/man/list_standards.Rd
@@ -4,7 +4,12 @@
 \alias{list_standards}
 \title{List all available standards}
 \usage{
-list_standards()
+list_standards(as = c("character", "list", "tibble"))
+}
+\arguments{
+\item{as}{Format to list the standards in.
+Default \code{character} just lists the names,
+while \code{list} and \code{tibble} show more detailed information.}
 }
 \value{
 \code{character} vector of standard names
@@ -13,7 +18,7 @@ list_standards()
 List all available mighty standard components.
 }
 \examples{
-available_standards <- list_standards()
-cat(available_standards, sep = "\n")
+list_standards()
 
+list_standards(as = "tibble")
 }

--- a/man/list_standards.Rd
+++ b/man/list_standards.Rd
@@ -4,12 +4,13 @@
 \alias{list_standards}
 \title{List all available standards}
 \usage{
-list_standards(as = c("character", "list", "tibble"))
+list_standards(as = c("character", "list", "tibble", "mcp"))
 }
 \arguments{
 \item{as}{Format to list the standards in.
 Default \code{character} just lists the names,
-while \code{list} and \code{tibble} show more detailed information.}
+while \code{list} and \code{tibble} show more detailed information.
+\code{mcp} returns a JSON list suitable for ingesting into LLMs as tools.}
 }
 \value{
 \code{character} vector of standard names
@@ -24,7 +25,12 @@ list_standards()
 # Tibble for an easy overview
 list_standards(as = "tibble")
 
-# List for tooling purposes (only showing first 2):
+# List (only showing first 2):
+list_standards(as = "list") |>
+  head(2) |>
+  str()
+
+# MCP for tooling purposes (only showing first 2):
 list_standards(as = "list") |>
   head(2) |>
   str()

--- a/man/list_standards.Rd
+++ b/man/list_standards.Rd
@@ -9,8 +9,7 @@ list_standards(as = c("character", "list", "tibble", "mcp"))
 \arguments{
 \item{as}{Format to list the standards in.
 Default \code{character} just lists the names,
-while \code{list} and \code{tibble} show more detailed information.
-\code{mcp} returns a JSON list suitable for ingesting into LLMs as tools.}
+while \code{list} and \code{tibble} show more detailed information.}
 }
 \value{
 \code{character} vector of standard names
@@ -26,11 +25,6 @@ list_standards()
 list_standards(as = "tibble")
 
 # List (only showing first 2):
-list_standards(as = "list") |>
-  head(2) |>
-  str()
-
-# MCP for tooling purposes (only showing first 2):
 list_standards(as = "list") |>
   head(2) |>
   str()

--- a/man/list_standards.Rd
+++ b/man/list_standards.Rd
@@ -18,7 +18,14 @@ while \code{list} and \code{tibble} show more detailed information.}
 List all available mighty standard components.
 }
 \examples{
+# Simple character list of all standard ids:
 list_standards()
 
+# Tibble for an easy overview
 list_standards(as = "tibble")
+
+# List for tooling purposes (only showing first 2):
+list_standards(as = "list") |>
+  head(2) |>
+  str()
 }

--- a/man/list_standards.Rd
+++ b/man/list_standards.Rd
@@ -4,7 +4,7 @@
 \alias{list_standards}
 \title{List all available standards}
 \usage{
-list_standards(as = c("character", "list", "tibble", "mcp"))
+list_standards(as = c("character", "list", "tibble"))
 }
 \arguments{
 \item{as}{Format to list the standards in.

--- a/man/mighty_component.Rd
+++ b/man/mighty_component.Rd
@@ -78,6 +78,12 @@ the rendered code used in mighty becomes:
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
+\item{\code{id}}{Component ID}
+
+\item{\code{title}}{Title for the component.}
+
+\item{\code{description}}{Description of the component.}
+
 \item{\code{code}}{The code block of the component.}
 
 \item{\code{template}}{The complete template.}
@@ -108,13 +114,15 @@ the rendered code used in mighty becomes:
 \subsection{Method \code{new()}}{
 Create standard component from template.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{mighty_component$new(template)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{mighty_component$new(template, id)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{template}}{\code{character} template code. See details for how to format.}
+
+\item{\code{id}}{\code{character} ID of the component. Either name of standard or path to local.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/mighty_component.Rd
+++ b/man/mighty_component.Rd
@@ -94,7 +94,7 @@ the rendered code used in mighty becomes:
 
 \item{\code{outputs}}{List of the new columns created by the component.}
 
-\item{\code{params}}{List of parameters that need to be supplied when rendering the component.}
+\item{\code{params}}{Data.frame listing parameters that need to be supplied when rendering the component.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/mighty_component_rendered.Rd
+++ b/man/mighty_component_rendered.Rd
@@ -46,13 +46,15 @@ Once rendered a component can be used to:
 \subsection{Method \code{new()}}{
 Create standard component from rendered template.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{mighty_component_rendered$new(template)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{mighty_component_rendered$new(template, id)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{template}}{\code{character} Rendered template such as output from \code{mighty_component$render()}.}
+
+\item{\code{id}}{\code{character} ID of the component. Either name of standard or path to local.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/_components/ady.R
+++ b/tests/testthat/_components/ady.R
@@ -1,4 +1,4 @@
-#' Analysis relative day
+#' @title Analysis relative day
 #' @description
 #' Derives the relative day compared to the treatment start date.
 #' @type derivation

--- a/tests/testthat/_components/ady_local.mustache
+++ b/tests/testthat/_components/ady_local.mustache
@@ -1,4 +1,4 @@
-#' Analysis relative day
+#' @title Analysis relative day
 #' @description
 #' Derives the relative day compared to the treatment start date.
 #'

--- a/tests/testthat/_snaps/component.md
+++ b/tests/testthat/_snaps/component.md
@@ -4,6 +4,8 @@
       x
     Message
       <mighty_component_rendered/mighty_component/R6>
+      _components/ady.R: Derives the relative day compared to the treatment start
+      date.
       Type: derivation
       Depends:
       * .self.A
@@ -26,6 +28,8 @@
       x
     Message
       <mighty_component_rendered/mighty_component/R6>
+      _components/ady_local.mustache: Derives the relative day compared to the
+      treatment start date.
       Type: derivation
       Depends:
       * .self.date_var
@@ -50,6 +54,7 @@
       y
     Message
       <mighty_component_rendered/mighty_component/R6>
+      ady: Derives the relative day compared to the treatment start date.
       Type: derivation
       Depends:
       * .self.date_var

--- a/tests/testthat/_snaps/components.md
+++ b/tests/testthat/_snaps/components.md
@@ -4,6 +4,7 @@
       predecessor
     Message
       <mighty_component_rendered/mighty_component/R6>
+      predecessor: Creates new column(s) based on a predecessor column(s).
       Type: predecessor
       Depends:
       * .self.USUBJID
@@ -24,6 +25,7 @@
       assign
     Message
       <mighty_component_rendered/mighty_component/R6>
+      assign: Assigns a single value to an entire column.
       Type: assigned
       Outputs:
       * y
@@ -39,6 +41,8 @@
       astdt
     Message
       <mighty_component_rendered/mighty_component/R6>
+      astdt: Derives analysis start date based on (incomplete) dates given as
+      character
       Type: derivation
       Depends:
       * .self.AESTDTC
@@ -65,6 +69,7 @@
       aendt
     Message
       <mighty_component_rendered/mighty_component/R6>
+      aendt: Derives analysis end date based on (incomplete) dates given as character
       Type: derivation
       Depends:
       * .self.AEENDTC
@@ -91,6 +96,7 @@
       ady
     Message
       <mighty_component_rendered/mighty_component/R6>
+      ady: Derives the relative day compared to the treatment start date.
       Type: derivation
       Depends:
       * .self.ASTDT
@@ -115,6 +121,7 @@
       trtemfl
     Message
       <mighty_component_rendered/mighty_component/R6>
+      trtemfl: Derives treatment emergent analysis flag.
       Type: derivation
       Depends:
       * .self.ASTDT
@@ -139,6 +146,7 @@
       supp_sdtm
     Message
       <mighty_component_rendered/mighty_component/R6>
+      supp_sdtm: Add a variable from a supplementary SDTM domain.
       Type: predecessor
       Depends:
       * .self.USUBJID

--- a/tests/testthat/test-standard.R
+++ b/tests/testthat/test-standard.R
@@ -2,6 +2,24 @@ test_that("list standards", {
   list_standards() |>
     expect_no_condition() |>
     expect_type("character")
+
+  list_standards("list") |>
+    expect_no_condition() |>
+    expect_type("list")
+
+  list_standards("tibble") |>
+    expect_no_condition() |>
+    expect_s3_class("tbl_df") |>
+    names() |>
+    expect_equal(c(
+      "id",
+      "title",
+      "description",
+      "params",
+      "depends",
+      "outputs",
+      "code"
+    ))
 })
 
 test_that("find standard", {


### PR DESCRIPTION
## Summary
Improves `list_standards()` to also be able to list standards as either a `list` or `tibble` with additional information about the standards.

## Changes Made
- Introduces `as` argument to `list_standards()` with the options `c("character", "list", "tibble")`
- Added `id`, `title`, and `description` as fields inside `mighty_component`
- Changed `params` in `mighty_component` to be a `data.frame` instead of a named character for easier downstream use
- Fixed bug in `get_tags()` so it now captures multiline tags - before it split by line.

## Testing
- Updated unit tests for `list_standards()`

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge
