### PR TITLE
fix: informative params errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mighty.standards
 Title: Standard derivations for ADaM generation
-Version: 0.0.0.9007
+Version: 0.0.0.9010
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@enovonordisk.com", role = c("aut", "cre")),
     person("Matthew", "Phelps", , "mewp@enovonordisk.com", role = c("aut")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Depends:
     R (>= 4.1)
 Imports: 
     cli,
+    glue,
     R6,
     rlang,
     roxygen2,

--- a/R/mighty_component.R
+++ b/R/mighty_component.R
@@ -238,11 +238,24 @@ ms_render <- function(params, self) {
     any(!names(params) %in% names(self$params)) ||
       any(!names(self$params) %in% names(params))
   ) {
+    missing_params <- setdiff(names(self$params), names(params))
+    unknown_params <- setdiff(names(params), names(self$params))
+
     cli::cli_abort(
       c(
-        "Parameter names not matching component requirements",
-        "x" = "Provided parameters: {.emph {names(params)}}",
-        "i" = "Expected parameters: {.field {names(self$params)}}"
+        "Parameter names not matching component requirements:",
+        glue::glue(
+          "{.code {{missing_params}}} not specified",
+          .open = "{{",
+          .close = "}}"
+        ) |>
+          rlang::set_names("x"),
+        glue::glue(
+          "{.code {{unknown_params}}} is unknown",
+          .open = "{{",
+          .close = "}}"
+        ) |>
+          rlang::set_names("x")
       )
     )
   }

--- a/R/mighty_component.R
+++ b/R/mighty_component.R
@@ -208,9 +208,10 @@ tags_to_params <- function(tags) {
         "x" = "Missing description for {.code {mistakes}}"
       )
     )
+  }
 
   params
-  }
+}
 
 #' @noRd
 tags_to_depends <- function(tags) {

--- a/R/mighty_component.R
+++ b/R/mighty_component.R
@@ -130,7 +130,7 @@ ms_initialize <- function(template, self, private) {
   # TODO: Input validation of template
   private$.type <- get_tag(template, "type")
   private$.params <- get_tags(template, "param") |>
-    tags_to_named()
+    tags_to_params()
   private$.depends <- get_tags(template, "depends") |>
     tags_to_depends()
   private$.outputs <- get_tags(template, "outputs")
@@ -164,10 +164,20 @@ get_tag <- function(template, tag) {
 }
 
 #' @noRd
-tags_to_named <- function(tags) {
+tags_to_params <- function(tags) {
   i <- regexpr(pattern = " ", text = tags)
 
   names(tags) <- substr(x = tags, start = 1, stop = i - 1)
+
+  if (any(!nchar(names(tags)))) {
+    cli::cli_abort(
+      c(
+        "All {.code @params} tags must have both a name and description:",
+        "x" = "Missing description for {.code {tags[!nchar(names(tags))]}}"
+      )
+    )
+  }
+
   tags <- substr(x = tags, start = i + 1, stop = nchar(tags))
   gsub(pattern = "^ +| +$", replacement = "", x = tags)
 }

--- a/tests/testthat/test-component.R
+++ b/tests/testthat/test-component.R
@@ -59,3 +59,17 @@ test_that("get_rendered_component returns rendered STANDARD code component with 
   )
   expect_equal(y$outputs, "out_var")
 })
+
+test_that("Error when any parameter insufficiently parameterized" , {
+  template <- c(
+  "#' @param variable",
+  "#' @param date ",
+  "#' @type derivation",
+  "#' @depends .self {{ date }}",
+  "#' @depends .self TRTSDT",
+  "#' @outputs {{ variable }}",
+  "print('hello')"
+)
+
+expect_error(mighty.standards::mighty_component$new(template), "Missing description for `variable` and `date`")
+})

--- a/tests/testthat/test-component.R
+++ b/tests/testthat/test-component.R
@@ -60,16 +60,24 @@ test_that("get_rendered_component returns rendered STANDARD code component with 
   expect_equal(y$outputs, "out_var")
 })
 
-test_that("Error when any parameter insufficiently parameterized" , {
+test_that("Error when any parameter insufficiently parameterized", {
   template <- c(
-  "#' @param variable",
-  "#' @param date ",
-  "#' @type derivation",
-  "#' @depends .self {{ date }}",
-  "#' @depends .self TRTSDT",
-  "#' @outputs {{ variable }}",
-  "print('hello')"
-)
+    "#' @title Mistake in parameters",
+    "#' @description This is a test component with missing parameters.",
+    "#' @param variable",
+    "#' @param date ",
+    "#' @type derivation",
+    "#' @depends .self {{ date }}",
+    "#' @depends .self TRTSDT",
+    "#' @outputs {{ variable }}",
+    "print('hello')"
+  )
 
-expect_error(mighty.standards::mighty_component$new(template), "Missing description for `variable` and `date`")
+  expect_error(
+    object = mighty.standards::mighty_component$new(
+      template = template,
+      id = "test_error"
+    ),
+    regexp = "Missing description for `variable` and `date`"
+  )
 })


### PR DESCRIPTION
## Summary
Improves error messages for when parameters are not correctly specified or supplied.

## Changes Made
1. `ms_initialize()` utility function `tags_to_named()` has been renamed to `tags_to_params()` to reflect it is only used to retrieve the parameters. When any parameter is insufficiently specified it now throws an error straight away. Closes #36.
2. The existing error message in `ms_render()` has been improved to list missing or unknown parameters in individual lines. Closes #37.

Example for 1:
``` r
template <- c(
  "#' @param variable ",
  "#' @param date ",
  "#' @type derivation",
  "#' @depends .self {{ date }}",
  "#' @depends .self TRTSDT",
  "#' @outputs {{ variable }}",
  "print('hello')"
)

mighty.standards::mighty_component$new(template)
#> Error in `tags_to_params()`:
#> ! All `@params` tags must have both a name and description:
#> ✖ Missing description for `variable` and `date`
```

<sup>Created on 2025-08-06 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

Example for 2:

``` r
mighty.standards::get_rendered_standard("ady")
#> Error in `ms_render()`:
#> ! Parameter names not matching component requirements:
#> ✖ `variable` not specified
#> ✖ `date` not specified

mighty.standards::get_rendered_standard(
  standard = "ady",
  params = list(variable = "b", fake_param = "a")
)
#> Error in `ms_render()`:
#> ! Parameter names not matching component requirements:
#> ✖ `date` not specified
#> ✖ `fake_param` is unknown
```

<sup>Created on 2025-08-06 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

## Testing
- No new unit testing needed.
- All existing unit tests passes.

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge
