### PR TITLE
feat: validate that @depends tags have both a domain and column

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mighty.component
 Title: Mighty Components for ADaM Generation
-Version: 0.0.0.9017
+Version: 0.0.0.9018
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@enovonordisk.com", role = c("aut", "cre")),
     person("Matthew", "Phelps", , "mewp@enovonordisk.com", role = c("aut")),

--- a/R/mighty_component.R
+++ b/R/mighty_component.R
@@ -215,7 +215,7 @@ tags_to_params <- function(tags) {
 tags_to_depends <- function(tags) {
   i <- regexpr(pattern = " +", text = tags)
 
-  data.frame(
+  depends <- data.frame(
     domain = tags |>
       substr(start = 1, stop = i - 1) |>
       trimws(),
@@ -223,6 +223,18 @@ tags_to_depends <- function(tags) {
       substr(start = i + 1, stop = nchar(tags)) |>
       trimws()
   )
+
+  mistakes <- tags[!nchar(depends$domain) | !nchar(depends$column)]
+  if (length(mistakes)) {
+    cli::cli_abort(
+      c(
+        "All {.code @depends} tags must have both a domain and column:",
+        "x" = "Not valid: {.code {mistakes}}"
+      )
+    )
+  }
+
+  depends
 }
 
 #' @noRd

--- a/tests/testthat/_components/test_coverage.mustache
+++ b/tests/testthat/_components/test_coverage.mustache
@@ -2,7 +2,7 @@
 #' @description
 #' This is a test component used for unit testing the workflow and coverage.
 #' @param value to assign to x
-#' @depends limit
+#' @depends domain limit
 #' @type derivation
 #' @code
 x <- {{ value }}

--- a/tests/testthat/test-mighty_component.R
+++ b/tests/testthat/test-mighty_component.R
@@ -181,6 +181,12 @@ test_that("tags_to_depends", {
     expect_named(c("domain", "column")) |>
     nrow() |>
     expect_equal(0)
+
+  tags_to_depends("USUBJID") |>
+    expect_error("must have both a domain and column")
+
+  tags_to_depends(c("data1 var1", "USUBJID")) |>
+    expect_error("must have both a domain and column")
 })
 
 test_that("print", {


### PR DESCRIPTION
# Pull request

## Summary
Closes #69

`tags_to_depends()` silently produced an empty-string domain when a `@depends` tag had only one value (e.g., `@depends USUBJID`). This adds validation matching what `tags_to_params()` already does for `@param` tags.

## Changes Made
- Added validation in `tags_to_depends()` that checks both domain and column are non-empty, aborting with a clear error listing the invalid tags
- Fixed `@depends limit` → `@depends domain limit` in the `test_coverage.mustache` test fixture
- Added error-case tests for single-value and mixed valid/invalid `@depends` tags

## Testing
- Added tests for `tags_to_depends("USUBJID")` and `tags_to_depends(c("data1 var1", "USUBJID"))` both expecting errors
- Full test suite passes

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge