### PR TITLE
feat: split @type mustache parameter into @type and @origin

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mighty.component
 Title: Mighty Components for ADaM Generation
-Version: 0.0.0.9018
+Version: 0.0.0.9019
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@enovonordisk.com", role = c("aut", "cre")),
     person("Matthew", "Phelps", , "mewp@enovonordisk.com", role = c("aut")),

--- a/R/mighty_component.R
+++ b/R/mighty_component.R
@@ -262,6 +262,9 @@ ms_print <- function(self) {
     cli::cli_text("{.cls {class(self)}}")
     cli::cli_text("{.field {self$id}}: {self$description}")
     cli::cli_text("{.emph Type:} {self$type}")
+    if (!is.null(self$origin)) {
+      cli::cli_text("{.emph Origin:} {self$origin}")
+    }
 
     create_bullets(
       header = "Parameters:",

--- a/R/mighty_component.R
+++ b/R/mighty_component.R
@@ -116,6 +116,8 @@ mighty_component <- R6::R6Class(
     template = \() private$.template,
     #' @field type The type of the component. Can be one of `r paste0(valid_types(), collapse = ", ")`.
     type = \() private$.type,
+    #' @field origin The CDISC origin of the component. Can be one of `r paste0(valid_origins(), collapse = ", ")` or `NULL`.
+    origin = \() private$.origin,
     #' @field depends Data.frame listing all the components dependencies.
     depends = \() private$.depends,
     #' @field outputs List of the new columns created by the component.
@@ -128,6 +130,7 @@ mighty_component <- R6::R6Class(
     .title = character(1),
     .description = character(1),
     .type = character(1),
+    .origin = NULL,
     .params = data.frame(
       name = character(),
       description = character()
@@ -144,7 +147,11 @@ ms_initialize <- function(template, id, self, private) {
   private$.id <- id
   private$.title <- get_tag(template, "title")
   private$.description <- get_tag(template, "description")
-  private$.type <- get_tag(template, "type")
+  private$.type <- get_tag(template, "type") |> assert_type()
+  private$.origin <- get_optional_tag(template, "origin")
+  if (!is.null(private$.origin)) {
+    assert_origin(private$.origin)
+  }
   private$.params <- get_tags(template, "param") |>
     tags_to_params()
   private$.depends <- get_tags(template, "depends") |>
@@ -183,6 +190,21 @@ get_tag <- function(template, tag) {
   }
 
   cli::cli_abort("Multiple or no matches found for tag: {tag}")
+}
+
+#' @noRd
+get_optional_tag <- function(template, tag) {
+  tags <- get_tags(template, tag)
+
+  if (length(tags) == 0L) {
+    return(NULL)
+  }
+
+  if (length(tags) == 1L) {
+    return(tags)
+  }
+
+  cli::cli_abort("Multiple matches found for tag: {tag}")
 }
 
 #' @noRd

--- a/R/mighty_component.R
+++ b/R/mighty_component.R
@@ -148,10 +148,7 @@ ms_initialize <- function(template, id, self, private) {
   private$.title <- get_tag(template, "title")
   private$.description <- get_tag(template, "description")
   private$.type <- get_tag(template, "type") |> assert_type()
-  private$.origin <- get_optional_tag(template, "origin")
-  if (!is.null(private$.origin)) {
-    assert_origin(private$.origin)
-  }
+  private$.origin <- get_optional_tag(template, "origin") |> assert_origin()
   private$.params <- get_tags(template, "param") |>
     tags_to_params()
   private$.depends <- get_tags(template, "depends") |>

--- a/R/mighty_component.R
+++ b/R/mighty_component.R
@@ -118,7 +118,7 @@ mighty_component <- R6::R6Class(
     template = \() private$.template,
     #' @field type The type of the component. Can be one of `r paste0(valid_types(), collapse = ", ")`.
     type = \() private$.type,
-    #' @field origin The CDISC origin of the component. Can be one of `r paste0(valid_origins(), collapse = ", ")` or `NULL`.
+    #' @field origin CDISC origin. One of `r paste0(valid_origins(), collapse = ", ")` or `NULL`.
     origin = \() private$.origin,
     #' @field depends Data.frame listing all the components dependencies.
     depends = \() private$.depends,

--- a/R/mighty_component.R
+++ b/R/mighty_component.R
@@ -264,9 +264,6 @@ ms_print <- function(self) {
     cli::cli_text("{.cls {class(self)}}")
     cli::cli_text("{.field {self$id}}: {self$description}")
     cli::cli_text("{.emph Type:} {self$type}")
-    if (!is.null(self$origin)) {
-      cli::cli_text("{.emph Origin:} {self$origin}")
-    }
 
     create_bullets(
       header = "Parameters:",

--- a/R/mighty_component.R
+++ b/R/mighty_component.R
@@ -22,7 +22,8 @@
 #' | `@title`       | Title of the component                               | `@title My component`    |
 #' | `@description` | Description of the component                         | `@description text text` |
 #' | `@param`       | Specifies input used to render the component         | `@param variable new var`|
-#' | `@type`        | Specifies type: `r mighty.component:::valid_types()` | `@type derivation`       |
+#' | `@type`        | Specifies type: `r mighty.component:::valid_types()` | `@type column`           |
+#' | `@origin`      | CDISC origin (optional)                              | `@origin Derived`        |
 #' | `@depends`     | Required input variable (repeat if several)          | `@depends {{ domain }} USUBJID` |
 #' | `@outputs`     | Variables created (repeat if several)                | `@outputs NEWVAR`        |
 #' | `@code`        | Everything under this tag defines the component code | `@code`                  |
@@ -49,7 +50,8 @@
 #' #'
 #' #' @param variable dynamic output if applicable
 #' #' @param x some other input to the component
-#' #' @type derivation
+#' #' @type column
+#' #' @origin Derived
 #' #' @depends {{ domain }} {{ x }}
 #' #' @outputs {{ variable }}
 #' #' @code

--- a/R/utils-validation.R
+++ b/R/utils-validation.R
@@ -15,6 +15,7 @@ valid_origins <- function() {
 }
 
 assert_origin <- function(origin) {
+  if (is.null(origin)) return(NULL)
   origins <- valid_origins()
   if (!origin %in% origins) {
     cli::cli_abort("@origin must be one of {.val {origins}}")

--- a/R/utils-validation.R
+++ b/R/utils-validation.R
@@ -1,5 +1,5 @@
 valid_types <- function() {
-  c("predecessor", "derivation", "row")
+  c("column", "row", "parameter", "internal")
 }
 
 assert_type <- function(type) {
@@ -8,4 +8,16 @@ assert_type <- function(type) {
     cli::cli_abort("@type must be one of {.val {types}}")
   }
   return(type)
+}
+
+valid_origins <- function() {
+  c("Assigned", "Collected", "Derived", "Not Available", "Other", "Predecessor", "Protocol")
+}
+
+assert_origin <- function(origin) {
+  origins <- valid_origins()
+  if (!origin %in% origins) {
+    cli::cli_abort("@origin must be one of {.val {origins}}")
+  }
+  return(origin)
 }

--- a/R/utils-validation.R
+++ b/R/utils-validation.R
@@ -7,7 +7,7 @@ assert_type <- function(type) {
   if (!type %in% types) {
     cli::cli_abort("@type must be one of {.val {types}}")
   }
-  return(type)
+  type
 }
 
 valid_origins <- function() {
@@ -20,5 +20,5 @@ assert_origin <- function(origin) {
   if (!origin %in% origins) {
     cli::cli_abort("@origin must be one of {.val {origins}}")
   }
-  return(origin)
+  origin
 }

--- a/inst/components/ady.mustache
+++ b/inst/components/ady.mustache
@@ -5,7 +5,8 @@
 #' @param domain `character` Name of new domain being created
 #' @param variable `character` Name of new variable to create
 #' @param date `character` Name of date variable to use
-#' @type derivation
+#' @type column
+#' @origin Derived
 #' @depends {{domain}} {{date}}
 #' @depends {{domain}} TRTSDT
 #' @outputs {{variable}}

--- a/inst/components/aendt.mustache
+++ b/inst/components/aendt.mustache
@@ -5,7 +5,8 @@
 #'
 #' @param domain `character` Name of new domain being created
 #' @param dtc `character` Name of date variable
-#' @type derivation
+#' @type column
+#' @origin Derived
 #' @depends {{domain}} {{dtc}}
 #' @outputs AENDT
 #' @outputs AENDTF

--- a/inst/components/assign.mustache
+++ b/inst/components/assign.mustache
@@ -5,7 +5,8 @@
 #' @param domain `character` Name of new domain being created
 #' @param variable `character` Name of variable to create or modify
 #' @param value Value to assign to the variable
-#' @type assigned
+#' @type column
+#' @origin Assigned
 #' @outputs {{variable}}
 #' @code
 {{domain}} <- {{domain}} |>

--- a/inst/components/astdt.mustache
+++ b/inst/components/astdt.mustache
@@ -5,7 +5,8 @@
 #'
 #' @param domain `character` Name of new domain being created
 #' @param dtc `character` Name of date variable
-#' @type derivation
+#' @type column
+#' @origin Derived
 #' @depends {{domain}} {{dtc}}
 #' @outputs ASTDT
 #' @outputs ASTDTF

--- a/inst/components/predecessor.mustache
+++ b/inst/components/predecessor.mustache
@@ -6,7 +6,8 @@
 #' @param source `character` Name of the data set the predecessor is from
 #' @param variable `character` Name of variable(s) to use from `source`
 #' @param by `character` name(s) of variable(s) to merge by
-#' @type predecessor
+#' @type column
+#' @origin Predecessor
 {{#by}}
 #' @depends {{domain}} {{.}}
 #' @depends {{source}} {{.}}

--- a/inst/components/supp_sdtm.mustache
+++ b/inst/components/supp_sdtm.mustache
@@ -5,7 +5,8 @@
 #' @param domain `character` Name of new domain being created
 #' @param source `character` Name of the supplementary data set to use
 #' @param qnam `character` Name of qualifier(s) to add from `source`
-#' @type predecessor
+#' @type column
+#' @origin Predecessor
 #' @depends {{domain}} USUBJID
 #' @depends {{source}} USUBJID
 #' @depends {{source}} IDVAR

--- a/inst/components/trtemfl.mustache
+++ b/inst/components/trtemfl.mustache
@@ -4,7 +4,8 @@
 #'
 #' @param domain `character` Name of new domain being created
 #' @param end_window Passed along to `admiral::end_window()`
-#' @type derivation
+#' @type column
+#' @origin Derived
 #' @depends {{domain}} ASTDT
 #' @depends {{domain}} AENDT
 #' @depends {{domain}} TRTSDT

--- a/tests/testthat/_components/ady_local.R
+++ b/tests/testthat/_components/ady_local.R
@@ -1,7 +1,8 @@
 #' @title Analysis relative day
 #' @description
 #' Derives the relative day compared to the treatment start date.
-#' @type derivation
+#' @type column
+#' @origin Derived
 #' @depends domain date_var
 #' @depends domain TRTSDT
 #' @outputs out_var

--- a/tests/testthat/_components/ady_local.mustache
+++ b/tests/testthat/_components/ady_local.mustache
@@ -5,7 +5,8 @@
 #' @param domain `character` Name of new domain being created
 #' @param variable `character` Name of new variable to create
 #' @param date `character` Name of date variable to use
-#' @type derivation
+#' @type column
+#' @origin Derived
 #' @depends {{domain}} {{ date }}
 #' @depends {{domain}} TRTSDT
 #' @outputs {{ variable }}

--- a/tests/testthat/_components/illegal_mustache.R
+++ b/tests/testthat/_components/illegal_mustache.R
@@ -1,6 +1,6 @@
 #' @title Illegal use of mustache patterns
 #' @description
 #' Mustache patterns not allowed in custom R component
-#' @type derivation
+#' @type column
 #' @code
 1 + {{ old_param }}

--- a/tests/testthat/_components/illegal_param.R
+++ b/tests/testthat/_components/illegal_param.R
@@ -1,7 +1,7 @@
 #' @title Illegal use of param tag
 #' @description
 #' Param tag not allowed in custom R component
-#' @type derivation
+#' @type column
 #' @param x Not allowed
 #' @code
 1 + 1

--- a/tests/testthat/_components/test_component.mustache
+++ b/tests/testthat/_components/test_component.mustache
@@ -4,7 +4,8 @@
 #' @param domain `character` Name of new domain being created
 #' @param x1 First input
 #' @param x2 Second input
-#' @type derivation
+#' @type column
+#' @origin Derived
 #' @depends {{domain}} A
 #' @depends Y B
 #' @outputs NEWVAR

--- a/tests/testthat/_components/test_coverage.mustache
+++ b/tests/testthat/_components/test_coverage.mustache
@@ -3,7 +3,7 @@
 #' This is a test component used for unit testing the workflow and coverage.
 #' @param value to assign to x
 #' @depends domain limit
-#' @type derivation
+#' @type column
 #' @code
 x <- {{ value }}
 

--- a/tests/testthat/_components/test_eval.mustache
+++ b/tests/testthat/_components/test_eval.mustache
@@ -3,6 +3,6 @@
 #' This is a test component used for unit testing eval
 #' @param x1 First input
 #' @param x2 Second input
-#' @type derivation
+#' @type column
 #' @code
 x + 5 + {{ x1 }} * {{ x2 }}

--- a/tests/testthat/_snaps/component.md
+++ b/tests/testthat/_snaps/component.md
@@ -7,7 +7,6 @@
       _components/ady_local.R: Derives the relative day compared to the treatment
       start date.
       Type: column
-      Origin: Derived
       Depends:
       * domain.date_var
       * domain.TRTSDT
@@ -34,7 +33,6 @@
       _components/ady_local.mustache: Derives the relative day compared to the
       treatment start date.
       Type: column
-      Origin: Derived
       Depends:
       * domain.date_var
       * domain.TRTSDT
@@ -60,7 +58,6 @@
       <mighty_component_rendered/mighty_component/R6>
       ady: Derives the relative day compared to the treatment start date.
       Type: column
-      Origin: Derived
       Depends:
       * domain.date_var
       * domain.TRTSDT

--- a/tests/testthat/_snaps/component.md
+++ b/tests/testthat/_snaps/component.md
@@ -6,7 +6,8 @@
       <mighty_component_rendered/mighty_component/R6>
       _components/ady_local.R: Derives the relative day compared to the treatment
       start date.
-      Type: derivation
+      Type: column
+      Origin: Derived
       Depends:
       * domain.date_var
       * domain.TRTSDT
@@ -32,7 +33,8 @@
       <mighty_component_rendered/mighty_component/R6>
       _components/ady_local.mustache: Derives the relative day compared to the
       treatment start date.
-      Type: derivation
+      Type: column
+      Origin: Derived
       Depends:
       * domain.date_var
       * domain.TRTSDT
@@ -57,7 +59,8 @@
     Message
       <mighty_component_rendered/mighty_component/R6>
       ady: Derives the relative day compared to the treatment start date.
-      Type: derivation
+      Type: column
+      Origin: Derived
       Depends:
       * domain.date_var
       * domain.TRTSDT

--- a/tests/testthat/_snaps/mighty_component.md
+++ b/tests/testthat/_snaps/mighty_component.md
@@ -5,7 +5,8 @@
     Message
       <mighty_component/R6>
       test: This is a test component used for unit testing
-      Type: derivation
+      Type: column
+      Origin: Derived
       Parameters:
       * domain: `character` Name of new domain being created
       * x1: First input
@@ -22,7 +23,7 @@
       test_component$document()
     Output
       ## test: My test component
-      *type: derivation*
+      *type: column*
       
       This is a test component used for unit testing
       
@@ -59,7 +60,8 @@
     Message
       <mighty_component_rendered/mighty_component/R6>
       test: This is a test component used for unit testing
-      Type: derivation
+      Type: column
+      Origin: Derived
       Depends:
       * domain.A
       * Y.B
@@ -77,7 +79,8 @@
       <mighty_component/R6>
       _components/test_component.mustache: This is a test component used for unit
       testing
-      Type: derivation
+      Type: column
+      Origin: Derived
       Parameters:
       * domain: `character` Name of new domain being created
       * x1: First input
@@ -104,7 +107,7 @@
       "document")
     Output
       ## _components/test_component.mustache: My test component
-      *type: derivation*
+      *type: column*
       
       This is a test component used for unit testing
       

--- a/tests/testthat/_snaps/mighty_component.md
+++ b/tests/testthat/_snaps/mighty_component.md
@@ -6,7 +6,6 @@
       <mighty_component/R6>
       test: This is a test component used for unit testing
       Type: column
-      Origin: Derived
       Parameters:
       * domain: `character` Name of new domain being created
       * x1: First input
@@ -61,7 +60,6 @@
       <mighty_component_rendered/mighty_component/R6>
       test: This is a test component used for unit testing
       Type: column
-      Origin: Derived
       Depends:
       * domain.A
       * Y.B
@@ -80,7 +78,6 @@
       _components/test_component.mustache: This is a test component used for unit
       testing
       Type: column
-      Origin: Derived
       Parameters:
       * domain: `character` Name of new domain being created
       * x1: First input

--- a/tests/testthat/_snaps/mighty_component_rendered.md
+++ b/tests/testthat/_snaps/mighty_component_rendered.md
@@ -7,7 +7,8 @@
       <mighty_component_rendered/mighty_component/R6>
       _components/test_component.mustache: This is a test component used for unit
       testing
-      Type: derivation
+      Type: column
+      Origin: Derived
       Depends:
       * domain.A
       * Y.B

--- a/tests/testthat/_snaps/mighty_component_rendered.md
+++ b/tests/testthat/_snaps/mighty_component_rendered.md
@@ -8,7 +8,6 @@
       _components/test_component.mustache: This is a test component used for unit
       testing
       Type: column
-      Origin: Derived
       Depends:
       * domain.A
       * Y.B

--- a/tests/testthat/_snaps/standard.md
+++ b/tests/testthat/_snaps/standard.md
@@ -7,7 +7,6 @@
       <mighty_component/R6>
       ady: Derives the relative day compared to the treatment start date.
       Type: column
-      Origin: Derived
       Parameters:
       * domain: `character` Name of new domain being created
       * variable: `character` Name of new variable to create
@@ -28,7 +27,6 @@
       <mighty_component_rendered/mighty_component/R6>
       ady: Derives the relative day compared to the treatment start date.
       Type: column
-      Origin: Derived
       Depends:
       * adsl.ASTDT
       * adsl.TRTSDT

--- a/tests/testthat/_snaps/standard.md
+++ b/tests/testthat/_snaps/standard.md
@@ -6,7 +6,8 @@
     Message
       <mighty_component/R6>
       ady: Derives the relative day compared to the treatment start date.
-      Type: derivation
+      Type: column
+      Origin: Derived
       Parameters:
       * domain: `character` Name of new domain being created
       * variable: `character` Name of new variable to create
@@ -26,7 +27,8 @@
     Message
       <mighty_component_rendered/mighty_component/R6>
       ady: Derives the relative day compared to the treatment start date.
-      Type: derivation
+      Type: column
+      Origin: Derived
       Depends:
       * adsl.ASTDT
       * adsl.TRTSDT

--- a/tests/testthat/test-component.R
+++ b/tests/testthat/test-component.R
@@ -1,6 +1,6 @@
 expect_ady <- function(x) {
   expect_s3_class(x, "mighty_component_rendered")
-  expect_equal(x$type, "derivation")
+  expect_equal(x$type, "column")
   expect_equal(
     x$depends,
     data.frame(domain = rep("domain", 2), column = c("date_var", "TRTSDT"))
@@ -63,7 +63,7 @@ test_that("Error when any parameter insufficiently parameterized", {
     "#' @description This is a test component with missing parameters.",
     "#' @param variable",
     "#' @param date ",
-    "#' @type derivation",
+    "#' @type column",
     "#' @depends {{ domain }} {{ date }}",
     "#' @depends {{ domain }} TRTSDT",
     "#' @outputs {{ variable }}",

--- a/tests/testthat/test-mighty_component.R
+++ b/tests/testthat/test-mighty_component.R
@@ -144,6 +144,23 @@ test_that("get_tag", {
     expect_error(regexp = "Multiple or no matches found for tag")
 })
 
+test_that("get_optional_tag", {
+  get_optional_tag(template = "#' @mytag myvalue", tag = "mytag") |>
+    expect_equal("myvalue")
+
+  get_optional_tag(
+    template = c("#' @myothertag content", "also unrelated"),
+    tag = "mytag"
+  ) |>
+    expect_null()
+
+  get_optional_tag(
+    template = c("#' @mytag myvalue", "#' @mytag myothervalue"),
+    tag = "mytag"
+  ) |>
+    expect_error(regexp = "Multiple matches found for tag")
+})
+
 test_that("tags_to_params", {
   tags_to_params("myparam myvalue") |>
     expect_equal(

--- a/tests/testthat/test-mighty_component.R
+++ b/tests/testthat/test-mighty_component.R
@@ -19,7 +19,10 @@ test_that("mighty_component", {
     expect_equal(readLines(component))
 
   test_component$type |>
-    expect_equal("derivation")
+    expect_equal("column")
+
+  test_component$origin |>
+    expect_equal("Derived")
 
   test_component$depends |>
     expect_s3_class("data.frame") |>
@@ -72,7 +75,10 @@ test_that("mighty_component", {
     expect_false()
 
   test_component_rendered$type |>
-    expect_equal("derivation")
+    expect_equal("column")
+
+  test_component_rendered$origin |>
+    expect_equal("Derived")
 
   test_component_rendered$depends |>
     expect_s3_class("data.frame") |>

--- a/tests/testthat/test-mighty_component_rendered.R
+++ b/tests/testthat/test-mighty_component_rendered.R
@@ -51,7 +51,7 @@ test_that("validation runs automatically when rendering component with invalid c
     "#' @param domain the data set being changes",
     "#' @param dataset The dataset to join",
     "#' @param join_type The type of join function",
-    "#' @type derivation",
+    "#' @type column",
     "#' @depends {{ domain }} USUBJID",
     "#' @outputs NEWVAR",
     "#' @code",

--- a/tests/testthat/test-utils-validation.R
+++ b/tests/testthat/test-utils-validation.R
@@ -3,53 +3,14 @@ test_that("type checks", {
     expect_no_condition() |>
     expect_equal("column")
 
-  assert_type("row") |>
-    expect_no_condition() |>
-    expect_equal("row")
-
-  assert_type("parameter") |>
-    expect_no_condition() |>
-    expect_equal("parameter")
-
-  assert_type("internal") |>
-    expect_no_condition() |>
-    expect_equal("internal")
-
-  assert_type("derivation") |>
-    expect_error()
-
   assert_type("illegal type") |>
     expect_error()
 })
 
 test_that("origin checks", {
-  assert_origin("Assigned") |>
-    expect_no_condition() |>
-    expect_equal("Assigned")
-
-  assert_origin("Collected") |>
-    expect_no_condition() |>
-    expect_equal("Collected")
-
   assert_origin("Derived") |>
     expect_no_condition() |>
     expect_equal("Derived")
-
-  assert_origin("Not Available") |>
-    expect_no_condition() |>
-    expect_equal("Not Available")
-
-  assert_origin("Other") |>
-    expect_no_condition() |>
-    expect_equal("Other")
-
-  assert_origin("Predecessor") |>
-    expect_no_condition() |>
-    expect_equal("Predecessor")
-
-  assert_origin("Protocol") |>
-    expect_no_condition() |>
-    expect_equal("Protocol")
 
   assert_origin(NULL) |>
     expect_no_condition() |>

--- a/tests/testthat/test-utils-validation.R
+++ b/tests/testthat/test-utils-validation.R
@@ -1,8 +1,56 @@
 test_that("type checks", {
-  assert_type("derivation") |>
+  assert_type("column") |>
     expect_no_condition() |>
-    expect_equal("derivation")
+    expect_equal("column")
+
+  assert_type("row") |>
+    expect_no_condition() |>
+    expect_equal("row")
+
+  assert_type("parameter") |>
+    expect_no_condition() |>
+    expect_equal("parameter")
+
+  assert_type("internal") |>
+    expect_no_condition() |>
+    expect_equal("internal")
+
+  assert_type("derivation") |>
+    expect_error()
 
   assert_type("illegal type") |>
+    expect_error()
+})
+
+test_that("origin checks", {
+  assert_origin("Assigned") |>
+    expect_no_condition() |>
+    expect_equal("Assigned")
+
+  assert_origin("Collected") |>
+    expect_no_condition() |>
+    expect_equal("Collected")
+
+  assert_origin("Derived") |>
+    expect_no_condition() |>
+    expect_equal("Derived")
+
+  assert_origin("Not Available") |>
+    expect_no_condition() |>
+    expect_equal("Not Available")
+
+  assert_origin("Other") |>
+    expect_no_condition() |>
+    expect_equal("Other")
+
+  assert_origin("Predecessor") |>
+    expect_no_condition() |>
+    expect_equal("Predecessor")
+
+  assert_origin("Protocol") |>
+    expect_no_condition() |>
+    expect_equal("Protocol")
+
+  assert_origin("illegal origin") |>
     expect_error()
 })

--- a/tests/testthat/test-utils-validation.R
+++ b/tests/testthat/test-utils-validation.R
@@ -51,6 +51,10 @@ test_that("origin checks", {
     expect_no_condition() |>
     expect_equal("Protocol")
 
+  assert_origin(NULL) |>
+    expect_no_condition() |>
+    expect_null()
+
   assert_origin("illegal origin") |>
     expect_error()
 })


### PR DESCRIPTION
# Pull request

Closes #79

## Summary

Split the `@type` mustache parameter into two separate tags: `@type` for mighty-internal categorization and `@origin` for CDISC standard documentation. This provides a clear distinction between information needed for mighty and metadata used in mighty.metadata/define.xml.

## Changes Made

- Updated `valid_types()` from `predecessor/derivation/row` to `column/row/parameter/internal`
- Added `valid_origins()` with 7 CDISC origin values: Assigned, Collected, Derived, Not Available, Other, Predecessor, Protocol
- Added `assert_origin()` validation function (NULL-safe for optional usage)
- Added `get_optional_tag()` helper that returns NULL on missing tags instead of erroring
- Wired `assert_type()` and `assert_origin()` into `ms_initialize()` for validation at component creation
- Added `.origin` private field and `origin` active binding to `mighty_component` R6 class
- Updated all 7 standard component templates with new `@type` and `@origin` values
- Updated all test fixtures, assertions, and snapshots

## Testing

- Updated `test-utils-validation.R` with tests for new type values, all origin values, and NULL origin
- Added `get_optional_tag` tests (match, no match, multiple match)
- Added `$origin` assertions in component integration tests
- Regenerated all snapshot files

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge